### PR TITLE
Only delete compressed files in backup rotation

### DIFF
--- a/automysqlbackup_plus
+++ b/automysqlbackup_plus
@@ -204,7 +204,7 @@ then
 	then
 		mkdir -p "${BACKUPDIR}/latest"
 	fi
-eval ${RM} -fv "${BACKUPDIR}/latest/*"
+eval ${RM} -fv "${BACKUPDIR}/latest/*.gz"
 fi
 
 


### PR DESCRIPTION
- Backup files will be compressed
- There are other files there that aren't, like SyncToy
